### PR TITLE
Change link on bug report button

### DIFF
--- a/static/js/values.js
+++ b/static/js/values.js
@@ -49,7 +49,7 @@ value('translation', {
     'submit-feedback': 'Отправить отзыв об этой странице',
 
     // GitHub issue template: update repo and messaging when translating.
-    'github-repo': 'github.com/golang/tour',
+    'github-repo': 'github.com/kalimatas/go-tour-ru',
     'issue-title': 'tour: [REPLACE WITH SHORT DESCRIPTION]',
     'issue-message': 'Change the title above to describe your issue and add your feedback here, including code if necessary',
     'context': 'Context',


### PR DESCRIPTION
Currently, the go-tour-ru-ru.appspot.com use bug report link to official (English) translation of Go Tour.  This cause many issues related to Russian tour translation reported to github.com/golang/tour instead of here. [1]

Please open the Issues tab so users can report the bug here, not at golang/tour.

[1] https://github.com/golang/tour/issues/550